### PR TITLE
Function for erasing the NAND / Usage section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ to support rk3066 Android dongles.
 
 Use install-debian.sh to install dependecies and type make to build it
 
+RK3188 support thanks to Omegamoon.
+
 rkflashtool
 ===========
 
@@ -25,4 +27,30 @@ Modified by Astralix to add some more informative console output
 
 Modified by Astralix to add parameters readout command 'p'
 
+Added in Omegamoon's RK3188 parameters.
 
+Merged in the "erase" function from Galland's rkflashtool_rk3066 (thesawolf)
+
+USAGE
+=====
+
+Read parameters:
+- sudo ./rkflashtool p > parm.bin
+- cat parm.bin
+- The output will show 2 hex numbers and the partition (,0x00008000@0x00010000(recovery),)
+- When using the rkflashtool, swap the 2 hex numbers found in the parm.bin for the respective partition
+- ie. Writing to recovery would be:
+sudo ./rkflashtool w 0x10000 0x8000 < recovery.img
+
+**command usage:**
+- rkflashtool b				reboot device
+- rkflashtool r offset size >file	read flash
+- rkflashtool w offset size <file	write flash
+
+- rkflashtool m offset size >file	read 0x80 bytes DRAM
+- rkflashtool i offset blocks >file	read IDB flash
+- rkflashtool p >file			fetch parameters
+
+- rkflashtool e offset size		erase flash (fill with 0xff)
+
+offset and size are in units (blocks) of 512 bytes

--- a/rkflashtool.c
+++ b/rkflashtool.c
@@ -37,8 +37,8 @@
 #include <string.h>
 #include <libusb-1.0/libusb.h>
 
-#define RKFLASHTOOL_VERSION_MAJOR      4
-#define RKFLASHTOOL_VERSION_MINOR      2
+#define RKFLASHTOOL_VERSION_MAJOR      3
+#define RKFLASHTOOL_VERSION_MINOR      3
 
 #define VID_RK              0x2207
 #define PID_RK2818          0x281a


### PR DESCRIPTION
Function added for erasing the NAND (for 'e' action)
Version number changed to 3.3
Readme updated with Usage section
